### PR TITLE
Use angle unwrapping instead of trigonometry

### DIFF
--- a/AverageAngle.cpp
+++ b/AverageAngle.cpp
@@ -19,48 +19,37 @@
 AverageAngle::AverageAngle(const enum AngleType type)
 {
   _type = type;
+  _half_turn = _type==RADIANS ? M_PI : 180;
+  _full_turn = 2 * _half_turn;
   reset();
 }
 
-void AverageAngle::add(float alpha, float length)
+void AverageAngle::add(float alpha)
 {
-  if (_type == AverageAngle::DEGREES )
-  {
-    alpha *= DEG_TO_RAD; 				// (PI / 180.0);
-  }
-  _sumx += (cos(alpha) * length);
-  _sumy += (sin(alpha) * length);
+  // Unwrap.
+  while (alpha < _last - _half_turn)
+    alpha += _full_turn;
+  while (alpha > _last + _half_turn)
+    alpha -= _full_turn;
+  _last = alpha;
+
+  _sum += alpha;
   _count++;
 }
 
 void AverageAngle::reset()
 {
-  _sumx = 0;
-  _sumy = 0;
+  _last = 0;
+  _sum = 0;
   _count = 0;
 }
 
 float AverageAngle::getAverage()
 {
-  float angle = atan2(_sumy, _sumx);
-  if (angle < 0) angle += TWO_PI;		//	(PI * 2);
-  if (_type == AverageAngle::DEGREES )
-  {
-    angle *=  RAD_TO_DEG; 				// (180.0 / PI);
-  }
-  return angle;
-}
-
-float AverageAngle::getTotalLength()
-{
-  if (_count == 0) return 0;
-  return hypot(_sumy, _sumx);
-}
-
-float AverageAngle::getAverageLength()
-{
-  if (_count == 0) return 0;
-  return hypot(_sumy, _sumx) / _count;
+  float avg = _sum/_count;
+  while (avg < 0) avg += _full_turn;
+  while (avg >= _full_turn) avg -= _full_turn;
+  return avg;
 }
 
 // -- END OF FILE --

--- a/AverageAngle.h
+++ b/AverageAngle.h
@@ -19,20 +19,19 @@ public:
 
     AverageAngle(const enum AngleType type = DEGREES);
 
-    void 	 add(float alpha, float length = 1.0);
+    void 	 add(float alpha);
     void 	 reset();
     uint32_t count() { return _count; };
     float    getAverage();
-
-    float    getTotalLength();
-    float    getAverageLength();
 
     enum     AngleType type() { return _type; };
 
 private:
     enum AngleType _type;
-    float _sumx;
-    float _sumy;
+    float _half_turn;
+    float _full_turn;
+    float _last;
+    float _sum;
     uint32_t _count;
 };
 


### PR DESCRIPTION
**Warning**: Draft PR, with breaking changes to the API, not to be merged.

This pull request is a followup on issue #1 (Trigonometry can be slow). It implements angle averaging by unwrapping. It contains some breaking changes:

* `add()` has no `length` parameter
* `getTotalLength()` and `getAverageLength()` have been removed.

The patch has been tested on an Uno using the following sketch:

```c++
#include <AverageAngle.h>

AverageAngle aa;

void setup() {
    uint16_t t0, t1;
    TCCR1A = 0;
    TCCR1B = _BV(CS10);
    Serial.begin(9600);

    for (int i = 0; i < 10; i++) {
        float x = 0.1 * random(-100, 101);
        if (x < 0) x += 360;
        t0 = TCNT1;
        aa.add(x);
        t1 = TCNT1;
        Serial.print("add(");
        Serial.print(x);
        Serial.print("): ");
        Serial.print(t1 - t0 - 4);
        Serial.println(" cycles");
    }

    t0 = TCNT1;
    float avg = aa.getAverage();
    t1 = TCNT1;
    Serial.print("getAverage() -> ");
    Serial.print(avg);
    Serial.print(": ");
    Serial.print(t1 - t0 - 4);
    Serial.println(" cycles");
}

void loop() {}
```

The output, with the master branch (commit cd2cf0333377e0d306daada1fae5989567b03311):

```text
add(2.40): 3945 cycles
add(0.00): 3164 cycles
add(8.80): 3947 cycles
add(354.10): 4016 cycles
add(354.60): 4090 cycles
add(1.30): 3975 cycles
add(2.00): 3959 cycles
add(358.90): 3995 cycles
add(2.20): 3974 cycles
add(355.20): 4046 cycles
getAverage() -> 359.95: 3538 cycles
```

With the pull request applied:

```text
add(2.40): 509 cycles
add(0.00): 600 cycles
add(8.80): 532 cycles
add(354.10): 939 cycles
add(354.60): 998 cycles
add(1.30): 621 cycles
add(2.00): 642 cycles
add(358.90): 984 cycles
add(2.20): 632 cycles
add(355.20): 1010 cycles
getAverage() -> 359.95: 883 cycles
```